### PR TITLE
Ensure newer versions of jquery handle total amount properly

### DIFF
--- a/js/civicrm_stripe.js
+++ b/js/civicrm_stripe.js
@@ -180,7 +180,10 @@
 
         $totalElement = $('#wf-crm-billing-total');
         if ($totalElement.length) {
-          if ($totalElement.data('data-amount') === '0') {
+          // Handle old and new jQuery conventions (https://api.jquery.com/data/#data-html5)
+          // The second form is the new form as of jQuery 1.4.3 (jQuery tries to convert string
+          // numbers to integers).
+          if ($totalElement.data('data-amount') === '0' || $totalElement.data('amount') === 0 ) {
             debugging('webform total is 0');
             return true;
           }


### PR DESCRIPTION
Without this patch, an attempt to submit a webform with a payment option
that totals $0 gets the error: Error: Could not find payment
information.

That's because the check for a total price of $0 fails. It fails for two
reasons:

1. Newer versions of jquery conform to html5 specs that say the data in
the field called "data-amount" should be referred to as simply "amount"
rather than "data-amount"

2. In addition, jquery now tries to convert values to their appropriate
type, so the strict matching of === '0' only matches on the string value
of '0' but jquery is converting the string '0' into the integer 0.